### PR TITLE
[FIX] kafka consumer id 변경 및 redis 수정

### DIFF
--- a/src/kafka/consumer.ts
+++ b/src/kafka/consumer.ts
@@ -2,9 +2,10 @@ import { kafka } from '../plugins/kafka.js';
 import { KafkaTopicConsumer } from './consumers/kafka.topic.consumer.js';
 import pino from 'pino';
 import BaseLogger = pino.BaseLogger;
+import process from 'node:process';
 
 export async function startConsumer(topicConsumers: KafkaTopicConsumer[], logger: BaseLogger) {
-  const consumer = kafka.consumer({ groupId: 'MATCH_GAME_SERVER', sessionTimeout: 10000 }); // Adjust groupId as needed
+  const consumer = kafka.consumer({ groupId: process.env.SERVER_NAME, sessionTimeout: 10000 }); // Adjust groupId as needed
   await consumer.connect();
 
   for (const topicConsumer of topicConsumers) {

--- a/src/kafka/consumer.ts
+++ b/src/kafka/consumer.ts
@@ -4,7 +4,7 @@ import pino from 'pino';
 import BaseLogger = pino.BaseLogger;
 
 export async function startConsumer(topicConsumers: KafkaTopicConsumer[], logger: BaseLogger) {
-  const consumer = kafka.consumer({ groupId: 'MAIN_GAME_SERVER', sessionTimeout: 10000 });
+  const consumer = kafka.consumer({ groupId: 'MATCH_GAME_SERVER', sessionTimeout: 10000 }); // Adjust groupId as needed
   await consumer.connect();
 
   for (const topicConsumer of topicConsumers) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,13 +12,14 @@ import BaseLogger = pino.BaseLogger;
 import { setDiContainer } from './plugins/container.js';
 
 let heartbeatInterval: NodeJS.Timeout;
+const REDIS_HEARTBEAT_TTL_SECONDS = 60 + 10;
 
 function registerSocketServer(diContainer: AwilixContainer) {
   const httpServer = createServer();
   const io = new SocketIOServer(httpServer);
   io.logger = logger;
-  io.diContainer = diContainer;
 
+  io.diContainer = diContainer;
   registerSocketGateway(diContainer, io);
   return { httpServer, io };
 }
@@ -35,11 +36,11 @@ function getMatchServerKey() {
 
 async function configureServer() {
   await redis.set(getMatchServerKey(), process.env.SERVER_NAME);
-  await redis.expire(getMatchServerKey(), 60 + 10);
+  await redis.expire(getMatchServerKey(), REDIS_HEARTBEAT_TTL_SECONDS);
 
   heartbeatInterval = setInterval(async () => {
     logger.info('Match Server Heartbeat');
-    await redis.expire(getMatchServerKey(), 60 + 10);
+    await redis.expire(getMatchServerKey(), REDIS_HEARTBEAT_TTL_SECONDS);
   }, 60 * 1000);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,9 +34,7 @@ function getMatchServerKey() {
 }
 
 async function configureServer() {
-  await redis.hSet(getMatchServerKey(), {
-    serverName: process.env.SERVER_NAME,
-  });
+  await redis.set(getMatchServerKey(), process.env.SERVER_NAME);
   await redis.expire(getMatchServerKey(), 60 + 10);
 
   heartbeatInterval = setInterval(async () => {


### PR DESCRIPTION
## 📝 작업 내용

- kafka consumer의 group id 를 변경하였습니다.
- redis의 서버의 정보(자신의 정보)를 저장하는 방식을 hash에서 string으로 변경하였습니다.