### PR TITLE
[FEATURE] 두 사용자 접속시 게임 시작

### DIFF
--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -6,15 +6,26 @@ import { Server } from 'socket.io';
 import { MATCH_SOCKET_EVENTS } from '../network/match.event.js';
 import { playerTypeSchema } from './game.schema.js';
 import { Logger } from 'pino';
+import { socketCountDownSchema } from '../network/schemas/count-down.socket.schema.js';
+
+interface GameSessionInfo {
+  gameSpace: GameSpace;
+  player1Connected: boolean;
+  player2Connected: boolean;
+  player1Id: number;
+  player2Id: number;
+  isGameStarted: boolean;
+  countdownStarted: boolean;
+}
 
 export default class GameSession {
-  private readonly gameSpaces: Map<number, GameSpace>;
+  private readonly gameSessions: Map<number, GameSessionInfo>;
 
   constructor(
     private readonly io: Server,
     private readonly logger: Logger,
   ) {
-    this.gameSpaces = new Map<number, GameSpace>();
+    this.gameSessions = new Map<number, GameSessionInfo>();
     this.startLoop();
   }
 
@@ -24,7 +35,10 @@ export default class GameSession {
 
     this.logger.info(`Game session started with fixed time step: ${fixedTimeStep} seconds`);
     setInterval(() => {
-      for (const [matchId, gameSpace] of this.gameSpaces.entries()) {
+      for (const [matchId, sessionInfo] of this.gameSessions.entries()) {
+        if (!sessionInfo.isGameStarted) continue;
+
+        const gameSpace = sessionInfo.gameSpace;
         gameSpace.step(fixedTimeStep);
 
         const message = {
@@ -36,7 +50,7 @@ export default class GameSession {
 
         if (gameSpace.getBallPosition().y <= 0) {
           // clearInterval(timer);
-          this.gameSpaces.delete(matchId);
+          this.gameSessions.delete(matchId);
         }
       }
     }, intervalMs);
@@ -59,20 +73,116 @@ export default class GameSession {
     const racket2 = new Racket(input.player2Id, playerTypeSchema.enum.PLAYER2);
     const gameSpace = new GameSpace(ball, table, racket1, racket2);
 
-    this.gameSpaces.set(input.matchId, gameSpace);
+    this.gameSessions.set(input.matchId, {
+      gameSpace,
+      player1Connected: false,
+      player2Connected: false,
+      player1Id: input.player1Id,
+      player2Id: input.player2Id,
+      isGameStarted: false,
+      countdownStarted: false,
+    });
   }
 
   updateRacketPosition(matchId: number, playerId: number, x: number, y: number, z: number) {
-    const gameSpace = this.gameSpaces.get(matchId);
-    if (!gameSpace) {
+    const sessionInfo = this.gameSessions.get(matchId);
+    if (!sessionInfo) {
       this.logger.error(`Game space for match ID ${matchId} not found.`);
       throw new Error(`Game space for match ID ${matchId} not found.`);
     }
 
-    gameSpace.updateRacketPosition(playerId, x, y, z);
+    sessionInfo.gameSpace.updateRacketPosition(playerId, x, y, z);
   }
 
   isExist(matchId: number): boolean {
-    return this.gameSpaces.has(matchId);
+    return this.gameSessions.has(matchId);
+  }
+
+  playerConnected(matchId: number, playerId: number): void {
+    const sessionInfo = this.gameSessions.get(matchId);
+    if (!sessionInfo) {
+      this.logger.error(`Game session for match ID ${matchId} not found.`);
+      return;
+    }
+
+    if (playerId === sessionInfo.player1Id) {
+      sessionInfo.player1Connected = true;
+      this.logger.info(`Player 1 (${playerId}) connected to match ${matchId}`);
+    } else if (playerId === sessionInfo.player2Id) {
+      sessionInfo.player2Connected = true;
+      this.logger.info(`Player 2 (${playerId}) connected to match ${matchId}`);
+    }
+
+    this.checkAndStartCountdown(matchId);
+  }
+
+  playerDisconnected(matchId: number, playerId: number): void {
+    const sessionInfo = this.gameSessions.get(matchId);
+    if (!sessionInfo) {
+      return;
+    }
+
+    if (playerId === sessionInfo.player1Id) {
+      sessionInfo.player1Connected = false;
+      this.logger.info(`Player 1 (${playerId}) disconnected from match ${matchId}`);
+    } else if (playerId === sessionInfo.player2Id) {
+      sessionInfo.player2Connected = false;
+      this.logger.info(`Player 2 (${playerId}) disconnected from match ${matchId}`);
+    }
+  }
+
+  private checkAndStartCountdown(matchId: number): void {
+    const sessionInfo = this.gameSessions.get(matchId);
+    if (!sessionInfo) return;
+
+    if (
+      sessionInfo.player1Connected &&
+      sessionInfo.player2Connected &&
+      !sessionInfo.countdownStarted
+    ) {
+      sessionInfo.countdownStarted = true;
+      this.logger.info(`Both players connected for match ${matchId}. Starting countdown.`);
+      this.startCountdown(matchId);
+    }
+  }
+
+  private startCountdown(matchId: number): void {
+    let countdown = 3;
+
+    const countdownInterval = setInterval(() => {
+      const sessionInfo = this.gameSessions.get(matchId);
+      if (!sessionInfo || !sessionInfo.player1Connected || !sessionInfo.player2Connected) {
+        clearInterval(countdownInterval);
+
+        if (sessionInfo) {
+          sessionInfo.countdownStarted = false;
+        }
+
+        this.logger.info(`Countdown cancelled for match ${matchId}: Player disconnected`);
+        this.io.to(`match:${matchId}`).emit(MATCH_SOCKET_EVENTS.COUNTDOWN_CANCELLED);
+        return;
+      }
+
+      this.io
+        .to(`match:${matchId}`)
+        .emit(MATCH_SOCKET_EVENTS.COUNTDOWN, socketCountDownSchema.parse({ count: countdown }));
+      this.logger.info(`Countdown for match ${matchId}: ${countdown}`);
+
+      countdown -= 1;
+
+      if (countdown < 0) {
+        clearInterval(countdownInterval);
+        this.startGame(matchId);
+      }
+    }, 1000);
+  }
+
+  private startGame(matchId: number): void {
+    const sessionInfo = this.gameSessions.get(matchId);
+    if (!sessionInfo) return;
+
+    sessionInfo.isGameStarted = true;
+    this.logger.info(`Game started for match ${matchId}`);
+    this.io.to(`match:${matchId}`).emit(MATCH_SOCKET_EVENTS.GAME_START);
   }
 }

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -290,10 +290,10 @@ export default class GameSession {
   private startCountdown(matchId: number): void {
     let countdown = 3;
 
-    const countdownInterval = setInterval(() => {
+    const countdownIntervalId = setInterval(() => {
       const sessionInfo = this.gameSessions.get(matchId);
       if (!sessionInfo || !sessionInfo.player1Connected || !sessionInfo.player2Connected) {
-        clearInterval(countdownInterval);
+        clearInterval(countdownIntervalId);
 
         if (sessionInfo) {
           sessionInfo.countdownStarted = false;
@@ -312,14 +312,14 @@ export default class GameSession {
       countdown -= 1;
 
       if (countdown < 0) {
-        clearInterval(countdownInterval);
+        clearInterval(countdownIntervalId);
         this.startGame(matchId);
       }
     }, 1000);
 
     const session = this.gameSessions.get(matchId);
     if (!session) return;
-    session.countdownIntervalId = countdownInterval;
+    session.countdownIntervalId = countdownIntervalId;
   }
 
   private startGame(matchId: number): void {

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -25,7 +25,8 @@ interface GameSessionInfo {
 export default class GameSession {
   private readonly gameSessions: Map<number, GameSessionInfo>;
   private readonly PLAYER_WAITING_TIMEOUT = 30 * 1000;
-  private readonly INITIAL_WAITING_TIMEOUT = 120 * 1000; // 120초 (2분) - 조정 가능
+  private readonly INITIAL_WAITING_TIMEOUT = 120 * 1000;
+  private readonly COUNTDOWN_SECONDS = 3;
 
   constructor(
     private readonly io: Server,
@@ -288,7 +289,7 @@ export default class GameSession {
       return;
     }
 
-    let countdown = 3;
+    let countdown = this.COUNTDOWN_SECONDS;
     sessionInfo.countdownStarted = true;
 
     const countdownIntervalId = setInterval(() => {

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -123,7 +123,7 @@ export default class GameSession {
     }
 
     if (sessionInfo.waitingTimeoutId) {
-      clearTimeout(sessionInfo.waitingTimeoutId);
+      clearInterval(sessionInfo.waitingTimeoutId);
       sessionInfo.waitingTimeoutId = null;
     }
 

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -89,8 +89,8 @@ export default class GameSession {
   updateRacketPosition(matchId: number, playerId: number, x: number, y: number, z: number) {
     const sessionInfo = this.gameSessions.get(matchId);
     if (!sessionInfo) {
-      this.logger.error(`Game space for match ID ${matchId} not found.`);
-      throw new Error(`Game space for match ID ${matchId} not found.`);
+      this.logger.error(`GameSession: Game space for match ID ${matchId} not found.`);
+      throw new Error(`GameSession: Game space for match ID ${matchId} not found.`);
     }
 
     sessionInfo.gameSpace.updateRacketPosition(playerId, x, y, z);

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -262,7 +262,7 @@ export default class GameSession {
     if (!sessionInfo) return;
 
     if (sessionInfo.waitingIntervalId) {
-      clearTimeout(sessionInfo.waitingIntervalId);
+      clearInterval(sessionInfo.waitingIntervalId);
     }
     if (sessionInfo.countdownIntervalId) {
       clearInterval(sessionInfo.countdownIntervalId);

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -297,9 +297,6 @@ export default class GameSession {
       if (!sessionInfo || !sessionInfo.player1Connected || !sessionInfo.player2Connected) {
         clearInterval(countdownIntervalId);
 
-        if (sessionInfo) {
-          sessionInfo.countdownStarted = false;
-        }
         this.logger.info(`Countdown cancelled for match ${matchId}: Player disconnected`);
         this.io.to(`match:${matchId}`).emit(MATCH_SOCKET_EVENTS.COUNTDOWN_CANCELLED);
         return;

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -196,9 +196,6 @@ export default class GameSession {
       }
 
       sessionInfo.playerWaitedTime += 1;
-
-      this.logger.info(sessionInfo.playerWaitedTime, 'Checking player waiting time for match:');
-      this.logger.info(this.PLAYER_WAITING_TIMEOUT, 'seconds');
       if (sessionInfo.playerWaitedTime * 1000 < this.PLAYER_WAITING_TIMEOUT) {
         const waitingForPlayerId = sessionInfo.player1Connected
           ? sessionInfo.player2Id

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -17,9 +17,9 @@ interface GameSessionInfo {
   player2Id: number;
   isGameStarted: boolean;
   countdownStarted: boolean;
-  countdownInterval: NodeJS.Timeout | null;
-  waitingTimeoutId: NodeJS.Timeout | null;
-  playerWaitingTime: number;
+  countdownIntervalId: NodeJS.Timeout | null;
+  waitingIntervalId: NodeJS.Timeout | null;
+  playerWaitedTime: number;
 }
 
 export default class GameSession {
@@ -87,9 +87,9 @@ export default class GameSession {
       player2Id: input.player2Id,
       isGameStarted: false,
       countdownStarted: false,
-      countdownInterval: null,
-      waitingTimeoutId: this.startInitialWaitingTimeout(input.matchId),
-      playerWaitingTime: 0,
+      countdownIntervalId: null,
+      waitingIntervalId: this.startInitialWaitingTimeout(input.matchId),
+      playerWaitedTime: 0,
     });
   }
 
@@ -122,16 +122,16 @@ export default class GameSession {
       this.logger.info(`Player 2 (${playerId}) connected to match ${matchId}`);
     }
 
-    if (sessionInfo.waitingTimeoutId) {
-      clearInterval(sessionInfo.waitingTimeoutId);
-      sessionInfo.waitingTimeoutId = null;
+    if (sessionInfo.waitingIntervalId) {
+      clearInterval(sessionInfo.waitingIntervalId);
+      sessionInfo.waitingIntervalId = null;
     }
 
     if (
       (sessionInfo.player1Connected && !sessionInfo.player2Connected) ||
       (!sessionInfo.player1Connected && sessionInfo.player2Connected)
     ) {
-      sessionInfo.waitingTimeoutId = this.startSinglePlayerWaitingTimeout(matchId);
+      sessionInfo.waitingIntervalId = this.startSinglePlayerWaitingInterval(matchId);
     }
 
     this.checkAndStartCountdown(matchId);
@@ -143,9 +143,9 @@ export default class GameSession {
       return;
     }
 
-    if (sessionInfo.countdownInterval) {
-      clearInterval(sessionInfo.countdownInterval);
-      sessionInfo.countdownInterval = null;
+    if (sessionInfo.countdownIntervalId) {
+      clearInterval(sessionInfo.countdownIntervalId);
+      sessionInfo.countdownIntervalId = null;
       sessionInfo.countdownStarted = false;
     }
 
@@ -161,16 +161,16 @@ export default class GameSession {
       return;
     }
 
-    if (sessionInfo.waitingTimeoutId) {
-      clearTimeout(sessionInfo.waitingTimeoutId);
-      sessionInfo.waitingTimeoutId = null;
+    if (sessionInfo.waitingIntervalId) {
+      clearInterval(sessionInfo.waitingIntervalId);
+      sessionInfo.waitingIntervalId = null;
     }
 
     if (sessionInfo.player1Connected || sessionInfo.player2Connected) {
-      sessionInfo.waitingTimeoutId = this.startSinglePlayerWaitingTimeout(matchId);
+      sessionInfo.waitingIntervalId = this.startSinglePlayerWaitingInterval(matchId);
       return;
     }
-    sessionInfo.waitingTimeoutId = this.startEmptySessionCleanupTimeout(matchId);
+    sessionInfo.waitingIntervalId = this.startEmptySessionCleanupTimeout(matchId);
   }
 
   private startInitialWaitingTimeout(matchId: number): NodeJS.Timeout {
@@ -188,7 +188,7 @@ export default class GameSession {
     }, this.INITIAL_WAITING_TIMEOUT);
   }
 
-  private startSinglePlayerWaitingTimeout(matchId: number): NodeJS.Timeout {
+  private startSinglePlayerWaitingInterval(matchId: number): NodeJS.Timeout {
     this.logger.info(`Starting single player waiting timeout for match ${matchId}`);
 
     return setInterval(() => {
@@ -198,21 +198,21 @@ export default class GameSession {
         return;
       }
 
-      sessionInfo.playerWaitingTime += 1;
+      sessionInfo.playerWaitedTime += 1;
 
-      this.logger.info(sessionInfo.playerWaitingTime, 'Checking player waiting time for match:');
+      this.logger.info(sessionInfo.playerWaitedTime, 'Checking player waiting time for match:');
       this.logger.info(this.PLAYER_WAITING_TIMEOUT, 'seconds');
-      if (sessionInfo.playerWaitingTime * 1000 < this.PLAYER_WAITING_TIMEOUT) {
+      if (sessionInfo.playerWaitedTime * 1000 < this.PLAYER_WAITING_TIMEOUT) {
         const waitingForPlayerId = sessionInfo.player1Connected
           ? sessionInfo.player2Id
           : sessionInfo.player1Id;
         this.logger.info(
-          `Waiting for player ${waitingForPlayerId} in match ${matchId}. Current waiting time: ${sessionInfo.playerWaitingTime} seconds`,
+          `Waiting for player ${waitingForPlayerId} in match ${matchId}. Current waiting time: ${sessionInfo.playerWaitedTime} seconds`,
         );
 
         this.io.to(`match:${matchId}`).emit(MATCH_SOCKET_EVENTS.WAITING_FOR_PLAYER, {
           waitingForPlayerId,
-          currentWaitingTimeInSeconds: sessionInfo.playerWaitingTime,
+          currentWaitingTimeInSeconds: sessionInfo.playerWaitedTime,
           timeoutInSeconds: this.PLAYER_WAITING_TIMEOUT / 1000,
         });
         return;
@@ -261,11 +261,11 @@ export default class GameSession {
     const sessionInfo = this.gameSessions.get(matchId);
     if (!sessionInfo) return;
 
-    if (sessionInfo.waitingTimeoutId) {
-      clearTimeout(sessionInfo.waitingTimeoutId);
+    if (sessionInfo.waitingIntervalId) {
+      clearTimeout(sessionInfo.waitingIntervalId);
     }
-    if (sessionInfo.countdownInterval) {
-      clearInterval(sessionInfo.countdownInterval);
+    if (sessionInfo.countdownIntervalId) {
+      clearInterval(sessionInfo.countdownIntervalId);
     }
 
     this.gameSessions.delete(matchId);
@@ -319,7 +319,7 @@ export default class GameSession {
 
     const session = this.gameSessions.get(matchId);
     if (!session) return;
-    session.countdownInterval = countdownInterval;
+    session.countdownIntervalId = countdownInterval;
   }
 
   private startGame(matchId: number): void {

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -288,7 +288,14 @@ export default class GameSession {
   }
 
   private startCountdown(matchId: number): void {
+    const sessionInfo = this.gameSessions.get(matchId);
+    if (!sessionInfo) {
+      this.logger.error(`GameSession: Game space for match ID ${matchId} not found.`);
+      return;
+    }
+
     let countdown = 3;
+    sessionInfo.countdownStarted = true;
 
     const countdownIntervalId = setInterval(() => {
       const sessionInfo = this.gameSessions.get(matchId);
@@ -298,7 +305,6 @@ export default class GameSession {
         if (sessionInfo) {
           sessionInfo.countdownStarted = false;
         }
-
         this.logger.info(`Countdown cancelled for match ${matchId}: Player disconnected`);
         this.io.to(`match:${matchId}`).emit(MATCH_SOCKET_EVENTS.COUNTDOWN_CANCELLED);
         return;
@@ -308,7 +314,6 @@ export default class GameSession {
         .to(`match:${matchId}`)
         .emit(MATCH_SOCKET_EVENTS.COUNTDOWN, socketCountDownSchema.parse({ count: countdown }));
       this.logger.info(`Countdown for match ${matchId}: ${countdown}`);
-
       countdown -= 1;
 
       if (countdown < 0) {
@@ -317,9 +322,7 @@ export default class GameSession {
       }
     }, 1000);
 
-    const session = this.gameSessions.get(matchId);
-    if (!session) return;
-    session.countdownIntervalId = countdownIntervalId;
+    sessionInfo.countdownIntervalId = countdownIntervalId;
   }
 
   private startGame(matchId: number): void {

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -127,10 +127,7 @@ export default class GameSession {
       sessionInfo.waitingIntervalId = null;
     }
 
-    if (
-      (sessionInfo.player1Connected && !sessionInfo.player2Connected) ||
-      (!sessionInfo.player1Connected && sessionInfo.player2Connected)
-    ) {
+    if (sessionInfo.player1Connected !== sessionInfo.player2Connected) {
       sessionInfo.waitingIntervalId = this.startSinglePlayerWaitingInterval(matchId);
     }
 

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -7,6 +7,7 @@ import { MATCH_SOCKET_EVENTS } from '../network/match.event.js';
 import { playerTypeSchema } from './game.schema.js';
 import { Logger } from 'pino';
 import { socketCountDownSchema } from '../network/schemas/count-down.socket.schema.js';
+import { socketMatchTimeoutSchema } from '../network/schemas/match-timout.socket.schema.js';
 
 interface GameSessionInfo {
   gameSpace: GameSpace;
@@ -17,10 +18,14 @@ interface GameSessionInfo {
   isGameStarted: boolean;
   countdownStarted: boolean;
   countdownInterval: NodeJS.Timeout | null;
+  waitingTimeoutId: NodeJS.Timeout | null;
+  playerWaitingTime: number;
 }
 
 export default class GameSession {
   private readonly gameSessions: Map<number, GameSessionInfo>;
+  private readonly PLAYER_WAITING_TIMEOUT = 30 * 1000;
+  private readonly INITIAL_WAITING_TIMEOUT = 120 * 1000; // 120초 (2분) - 조정 가능
 
   constructor(
     private readonly io: Server,
@@ -50,7 +55,7 @@ export default class GameSession {
         this.io.to(`match:${matchId}`).emit(MATCH_SOCKET_EVENTS.GAME_STATE, message);
 
         if (gameSpace.getBallPosition().y <= 0) {
-          // clearInterval(timer);
+          this.cleanupMatchSession(matchId);
           this.gameSessions.delete(matchId);
         }
       }
@@ -83,6 +88,8 @@ export default class GameSession {
       isGameStarted: false,
       countdownStarted: false,
       countdownInterval: null,
+      waitingTimeoutId: this.startInitialWaitingTimeout(input.matchId),
+      playerWaitingTime: 0,
     });
   }
 
@@ -115,6 +122,18 @@ export default class GameSession {
       this.logger.info(`Player 2 (${playerId}) connected to match ${matchId}`);
     }
 
+    if (sessionInfo.waitingTimeoutId) {
+      clearTimeout(sessionInfo.waitingTimeoutId);
+      sessionInfo.waitingTimeoutId = null;
+    }
+
+    if (
+      (sessionInfo.player1Connected && !sessionInfo.player2Connected) ||
+      (!sessionInfo.player1Connected && sessionInfo.player2Connected)
+    ) {
+      sessionInfo.waitingTimeoutId = this.startSinglePlayerWaitingTimeout(matchId);
+    }
+
     this.checkAndStartCountdown(matchId);
   }
 
@@ -127,6 +146,7 @@ export default class GameSession {
     if (sessionInfo.countdownInterval) {
       clearInterval(sessionInfo.countdownInterval);
       sessionInfo.countdownInterval = null;
+      sessionInfo.countdownStarted = false;
     }
 
     if (playerId === sessionInfo.player1Id) {
@@ -136,6 +156,120 @@ export default class GameSession {
       sessionInfo.player2Connected = false;
       this.logger.info(`Player 2 (${playerId}) disconnected from match ${matchId}`);
     }
+
+    if (sessionInfo.isGameStarted) {
+      return;
+    }
+
+    if (sessionInfo.waitingTimeoutId) {
+      clearTimeout(sessionInfo.waitingTimeoutId);
+      sessionInfo.waitingTimeoutId = null;
+    }
+
+    if (sessionInfo.player1Connected || sessionInfo.player2Connected) {
+      sessionInfo.waitingTimeoutId = this.startSinglePlayerWaitingTimeout(matchId);
+      return;
+    }
+    sessionInfo.waitingTimeoutId = this.startEmptySessionCleanupTimeout(matchId);
+  }
+
+  private startInitialWaitingTimeout(matchId: number): NodeJS.Timeout {
+    return setTimeout(() => {
+      const sessionInfo = this.gameSessions.get(matchId);
+      if (!sessionInfo) return;
+
+      // 아무 플레이어도 접속하지 않은 경우 세션 정리
+      if (!sessionInfo.player1Connected && !sessionInfo.player2Connected) {
+        this.logger.info(
+          `Match ${matchId} timed out: No players connected within ${this.INITIAL_WAITING_TIMEOUT / 1000} seconds`,
+        );
+        this.cleanupMatchSession(matchId);
+      }
+    }, this.INITIAL_WAITING_TIMEOUT);
+  }
+
+  private startSinglePlayerWaitingTimeout(matchId: number): NodeJS.Timeout {
+    this.logger.info(`Starting single player waiting timeout for match ${matchId}`);
+
+    return setInterval(() => {
+      const sessionInfo = this.gameSessions.get(matchId);
+      if (!sessionInfo) {
+        this.logger.error(`GameSession: Game space for match ID ${matchId} not found.`);
+        return;
+      }
+
+      sessionInfo.playerWaitingTime += 1;
+
+      this.logger.info(sessionInfo.playerWaitingTime, 'Checking player waiting time for match:');
+      this.logger.info(this.PLAYER_WAITING_TIMEOUT, 'seconds');
+      if (sessionInfo.playerWaitingTime * 1000 < this.PLAYER_WAITING_TIMEOUT) {
+        const waitingForPlayerId = sessionInfo.player1Connected
+          ? sessionInfo.player2Id
+          : sessionInfo.player1Id;
+        this.logger.info(
+          `Waiting for player ${waitingForPlayerId} in match ${matchId}. Current waiting time: ${sessionInfo.playerWaitingTime} seconds`,
+        );
+
+        this.io.to(`match:${matchId}`).emit(MATCH_SOCKET_EVENTS.WAITING_FOR_PLAYER, {
+          waitingForPlayerId,
+          currentWaitingTimeInSeconds: sessionInfo.playerWaitingTime,
+          timeoutInSeconds: this.PLAYER_WAITING_TIMEOUT / 1000,
+        });
+        return;
+      }
+
+      if (
+        (sessionInfo.player1Connected && !sessionInfo.player2Connected) ||
+        (!sessionInfo.player1Connected && sessionInfo.player2Connected)
+      ) {
+        const missingPlayerId = sessionInfo.player1Connected
+          ? sessionInfo.player2Id
+          : sessionInfo.player1Id;
+
+        this.logger.info(
+          `Match ${matchId} timed out: Waiting for player ${missingPlayerId} exceeded ${this.PLAYER_WAITING_TIMEOUT / 1000} seconds`,
+        );
+        this.io.to(`match:${matchId}`).emit(
+          MATCH_SOCKET_EVENTS.MATCH_TIMEOUT,
+          socketMatchTimeoutSchema.parse({
+            missingPlayerId,
+            waitingTimeInSeconds: this.PLAYER_WAITING_TIMEOUT / 1000,
+            reason: `Player ${missingPlayerId} did not connect within the time limit`,
+          }),
+        );
+
+        this.cleanupMatchSession(matchId);
+      }
+    }, 1000);
+  }
+
+  private startEmptySessionCleanupTimeout(matchId: number): NodeJS.Timeout {
+    return setTimeout(() => {
+      const sessionInfo = this.gameSessions.get(matchId);
+      if (!sessionInfo) return;
+
+      if (!sessionInfo.player1Connected && !sessionInfo.player2Connected) {
+        this.logger.info(
+          `Match ${matchId} cleanup: All players disconnected for ${this.PLAYER_WAITING_TIMEOUT / 1000} seconds`,
+        );
+        this.cleanupMatchSession(matchId);
+      }
+    }, this.PLAYER_WAITING_TIMEOUT);
+  }
+
+  private cleanupMatchSession(matchId: number): void {
+    const sessionInfo = this.gameSessions.get(matchId);
+    if (!sessionInfo) return;
+
+    if (sessionInfo.waitingTimeoutId) {
+      clearTimeout(sessionInfo.waitingTimeoutId);
+    }
+    if (sessionInfo.countdownInterval) {
+      clearInterval(sessionInfo.countdownInterval);
+    }
+
+    this.gameSessions.delete(matchId);
+    this.logger.info(`Match session ${matchId} has been cleaned up`);
   }
 
   private checkAndStartCountdown(matchId: number): void {
@@ -158,7 +292,6 @@ export default class GameSession {
 
     const countdownInterval = setInterval(() => {
       const sessionInfo = this.gameSessions.get(matchId);
-      this.gameSessions.get(matchId)!.countdownInterval = countdownInterval;
       if (!sessionInfo || !sessionInfo.player1Connected || !sessionInfo.player2Connected) {
         clearInterval(countdownInterval);
 
@@ -183,6 +316,10 @@ export default class GameSession {
         this.startGame(matchId);
       }
     }, 1000);
+
+    const session = this.gameSessions.get(matchId);
+    if (!session) return;
+    session.countdownInterval = countdownInterval;
   }
 
   private startGame(matchId: number): void {

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -16,6 +16,7 @@ interface GameSessionInfo {
   player2Id: number;
   isGameStarted: boolean;
   countdownStarted: boolean;
+  countdownInterval: NodeJS.Timeout | null;
 }
 
 export default class GameSession {
@@ -81,6 +82,7 @@ export default class GameSession {
       player2Id: input.player2Id,
       isGameStarted: false,
       countdownStarted: false,
+      countdownInterval: null,
     });
   }
 
@@ -122,6 +124,11 @@ export default class GameSession {
       return;
     }
 
+    if (sessionInfo.countdownInterval) {
+      clearInterval(sessionInfo.countdownInterval);
+      sessionInfo.countdownInterval = null;
+    }
+
     if (playerId === sessionInfo.player1Id) {
       sessionInfo.player1Connected = false;
       this.logger.info(`Player 1 (${playerId}) disconnected from match ${matchId}`);
@@ -151,6 +158,7 @@ export default class GameSession {
 
     const countdownInterval = setInterval(() => {
       const sessionInfo = this.gameSessions.get(matchId);
+      this.gameSessions.get(matchId)!.countdownInterval = countdownInterval;
       if (!sessionInfo || !sessionInfo.player1Connected || !sessionInfo.player2Connected) {
         clearInterval(countdownInterval);
 

--- a/src/domain/physics/Racket.ts
+++ b/src/domain/physics/Racket.ts
@@ -6,7 +6,7 @@ export default class Racket {
 
   constructor(
     private readonly playerId: number,
-    playerType: PlayerType,
+    _playerType: PlayerType,
   ) {
     const material = new CANNON.Material('racketMaterial');
     this.body = new CANNON.Body({

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -3,7 +3,7 @@ import { pino } from 'pino';
 export const logger = pino({
   transport: {
     target: 'pino-pretty',
-    level: 'debug',
+    level: process.env.LOG_LEVEL || 'info',
     options: {
       colorize: true,
       translateTime: 'yyyy-mm-dd HH:MM:ss',

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -3,6 +3,7 @@ import { pino } from 'pino';
 export const logger = pino({
   transport: {
     target: 'pino-pretty',
+    level: 'debug',
     options: {
       colorize: true,
       translateTime: 'yyyy-mm-dd HH:MM:ss',

--- a/src/network/match.event.ts
+++ b/src/network/match.event.ts
@@ -7,4 +7,5 @@ export const MATCH_SOCKET_EVENTS = {
   GAME_START: 'game-start',
   PLAYER_CONNECTED: 'player-connected',
   PLAYER_DISCONNECTED: 'player-disconnected',
+  WAITING_FOR_PLAYER: 'waiting-for-player',
 };

--- a/src/network/match.event.ts
+++ b/src/network/match.event.ts
@@ -2,4 +2,9 @@ export const MATCH_SOCKET_EVENTS = {
   RACKET: 'match-racket-update',
   GAME_STATE: 'game-state-update',
   GAME_OVER: 'game-over',
+  COUNTDOWN: 'game-countdown',
+  COUNTDOWN_CANCELLED: 'game-countdown-cancelled',
+  GAME_START: 'game-start',
+  PLAYER_CONNECTED: 'player-connected',
+  PLAYER_DISCONNECTED: 'player-disconnected',
 };

--- a/src/network/match.event.ts
+++ b/src/network/match.event.ts
@@ -8,4 +8,5 @@ export const MATCH_SOCKET_EVENTS = {
   PLAYER_CONNECTED: 'player-connected',
   PLAYER_DISCONNECTED: 'player-disconnected',
   WAITING_FOR_PLAYER: 'waiting-for-player',
+  MATCH_TIMEOUT: 'match-timeout',
 };

--- a/src/network/schemas/count-down.socket.schema.ts
+++ b/src/network/schemas/count-down.socket.schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const socketCountDownSchema = z.object({
+  count: z.number().min(0).max(3).describe('Count down value for the game start countdown'),
+});

--- a/src/network/schemas/match-timout.socket.schema.ts
+++ b/src/network/schemas/match-timout.socket.schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const socketMatchTimeoutSchema = z.object({
+  missingPlayerId: z.number(),
+  waitingTimeInSeconds: z.number().min(0, 'Waiting time must be a non-negative number'),
+  reason: z.string().optional(),
+});

--- a/src/network/schemas/player-id.socket.schema.ts
+++ b/src/network/schemas/player-id.socket.schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const socketPlayerIdSchema = z.object({
+  playerId: z.number(),
+});

--- a/src/network/socket.ts
+++ b/src/network/socket.ts
@@ -4,6 +4,7 @@ import { socketMiddleware } from './utils/middleware.js';
 import { matchMiddleware } from './match.middleware.js';
 import GameSession from '../domain/GameSession.js';
 import { MATCH_SOCKET_EVENTS } from './match.event.js';
+import { socketPlayerIdSchema } from './schemas/player-id.socket.schema.js';
 
 export const registerSocket = (diContainer: AwilixContainer, io: Server) => {
   io.use(socketMiddleware);
@@ -25,13 +26,28 @@ export const registerSocket = (diContainer: AwilixContainer, io: Server) => {
       `New connection: ${socket.id} from user ${socket.data.userId} joined match ${matchId}`,
     );
 
+    gameSession.playerConnected(matchId, playerId);
+    socket
+      .to(`match:${matchId}`)
+      .emit(MATCH_SOCKET_EVENTS.PLAYER_CONNECTED, socketPlayerIdSchema.parse({ playerId }));
     socket.on(MATCH_SOCKET_EVENTS.RACKET, (data) => {
       const { x, y, z } = data;
+      if (!gameSession.isExist(matchId)) {
+        return;
+      }
       gameSession.updateRacketPosition(matchId, playerId, x, y, z);
     });
 
     socket.on('disconnect', () => {
       logger.info(`User ${playerId} disconnected from match ${matchId}`);
+
+      gameSession.playerDisconnected(matchId, playerId);
+      socket.to(`match:${matchId}`).emit(
+        MATCH_SOCKET_EVENTS.PLAYER_DISCONNECTED,
+        socketPlayerIdSchema.parse({
+          playerId,
+        }),
+      );
       socket.leave(`match:${matchId}`);
     });
   });

--- a/src/network/socket.ts
+++ b/src/network/socket.ts
@@ -34,7 +34,7 @@ export const registerSocket = (diContainer: AwilixContainer, io: Server) => {
       const { x, y, z } = data;
       if (!gameSession.isExist(matchId)) {
         logger.error(`Match ${matchId} does not exist for player ${playerId}`);
-        throw new Error(`Match ${matchId} does not exist for player ${playerId}`);
+        return;
       }
       gameSession.updateRacketPosition(matchId, playerId, x, y, z);
     });

--- a/src/network/socket.ts
+++ b/src/network/socket.ts
@@ -33,7 +33,8 @@ export const registerSocket = (diContainer: AwilixContainer, io: Server) => {
     socket.on(MATCH_SOCKET_EVENTS.RACKET, (data) => {
       const { x, y, z } = data;
       if (!gameSession.isExist(matchId)) {
-        return;
+        logger.error(`Match ${matchId} does not exist for player ${playerId}`);
+        throw new Error(`Match ${matchId} does not exist for player ${playerId}`);
       }
       gameSession.updateRacketPosition(matchId, playerId, x, y, z);
     });


### PR DESCRIPTION
## 📝 작업 내용

게임 플레이 로직 관련 수정이 있었습니다.
게임을 시작하기 전 두 사용자 모두 접속 후 게임이 시작될 수 있도록 하였습니다.
- 플레이어 게임 접속시 상태 변경.
- 두 플레이어 모두 접속시 카운트 다운 후 게임 시작. 
- 두 플레이어중 한 플레이어만 접속하거나 둘 다 접속하지 않을 경우 타임아웃 처리 구현.
