### PR TITLE
[FEATURE] 충돌관련 데이터 저장하기

### DIFF
--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -55,12 +55,25 @@ export default class GameSession {
         };
         this.io.to(`match:${matchId}`).emit(MATCH_SOCKET_EVENTS.GAME_STATE, message);
 
+        this.logger.debug(gameSpace.getBallCollisionData(), 'BallCollisionData:');
+        this.logger.debug(gameSpace.getBallLastRacketPlayerId(), 'LastRacketPlayerId:');
+        this.logger.debug(gameSpace.getBallLastTableType(), 'LastTableType:');
+
         if (gameSpace.getBallPosition().y <= 0) {
           this.cleanupMatchSession(matchId);
           this.gameSessions.delete(matchId);
         }
       }
     }, intervalMs);
+  }
+
+  getPlayerIds(matchId: number): number[] {
+    const sessionInfo = this.gameSessions.get(matchId);
+    if (!sessionInfo) {
+      this.logger.error(`GameSession: Game space for match ID ${matchId} not found.`);
+      throw new Error(`GameSession: Game space for match ID ${matchId} not found.`);
+    }
+    return [sessionInfo.player1Id, sessionInfo.player2Id];
   }
 
   createGameSpace(input: {

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -54,10 +54,9 @@ export default class GameSession {
           racket2: gameSpace.getRacket2Position(),
         };
         this.io.to(`match:${matchId}`).emit(MATCH_SOCKET_EVENTS.GAME_STATE, message);
-
-        this.logger.debug(gameSpace.getBallCollisionData(), 'BallCollisionData:');
-        this.logger.debug(gameSpace.getBallLastRacketPlayerId(), 'LastRacketPlayerId:');
-        this.logger.debug(gameSpace.getBallLastTableType(), 'LastTableType:');
+        this.logger.info(gameSpace.getBallCollisionData(), 'BallCollisionData:');
+        this.logger.info(gameSpace.getBallLastRacketPlayerId(), 'LastRacketPlayerId:');
+        this.logger.info(gameSpace.getBallLastTableType(), 'LastTableType:');
 
         if (gameSpace.getBallPosition().y <= 0) {
           this.cleanupMatchSession(matchId);

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -1,6 +1,6 @@
 import GameSpace from './physics/GameSpace.js';
 import Ball from './physics/Ball.js';
-import Table from './physics/Table.js';
+import Table, { TableType } from './physics/Table.js';
 import Racket from './physics/Racket.js';
 import { Server } from 'socket.io';
 import { MATCH_SOCKET_EVENTS } from '../network/match.event.js';
@@ -75,10 +75,12 @@ export default class GameSession {
     this.logger.info(`Creating game space for match ID ${input.matchId}`);
 
     const ball = new Ball();
-    const table = new Table();
+    // 두 개의 테이블 생성 (플레이어 1, 플레이어 2 측)
+    const tablePlayer1 = new Table(TableType.PLAYER1);
+    const tablePlayer2 = new Table(TableType.PLAYER2);
     const racket1 = new Racket(input.player1Id, playerTypeSchema.enum.PLAYER1);
     const racket2 = new Racket(input.player2Id, playerTypeSchema.enum.PLAYER2);
-    const gameSpace = new GameSpace(ball, table, racket1, racket2);
+    const gameSpace = new GameSpace(ball, tablePlayer1, tablePlayer2, racket1, racket2);
 
     this.gameSessions.set(input.matchId, {
       gameSpace,

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -62,6 +62,7 @@ export default class GameSession {
         if (gameSpace.getBallPosition().y <= 0) {
           this.cleanupMatchSession(matchId);
           this.gameSessions.delete(matchId);
+          this.io.to(`match:${matchId}`).disconnectSockets();
         }
       }
     }, intervalMs);

--- a/src/domain/GameSession.ts
+++ b/src/domain/GameSession.ts
@@ -54,9 +54,9 @@ export default class GameSession {
           racket2: gameSpace.getRacket2Position(),
         };
         this.io.to(`match:${matchId}`).emit(MATCH_SOCKET_EVENTS.GAME_STATE, message);
-        this.logger.info(gameSpace.getBallCollisionData(), 'BallCollisionData:');
-        this.logger.info(gameSpace.getBallLastRacketPlayerId(), 'LastRacketPlayerId:');
-        this.logger.info(gameSpace.getBallLastTableType(), 'LastTableType:');
+        this.logger.debug(gameSpace.getBallCollisionData(), 'BallCollisionData:');
+        this.logger.debug(gameSpace.getBallLastRacketPlayerId(), 'LastRacketPlayerId:');
+        this.logger.debug(gameSpace.getBallLastTableType(), 'LastTableType:');
 
         if (gameSpace.getBallPosition().y <= 0) {
           this.cleanupMatchSession(matchId);

--- a/src/domain/physics/Ball.ts
+++ b/src/domain/physics/Ball.ts
@@ -1,7 +1,15 @@
 import * as CANNON from 'cannon-es';
+import { TableType } from './Table.js';
 
 export default class Ball {
   public body: CANNON.Body;
+
+  // 충돌 데이터 저장을 위한 변수들
+  private lastRacketPlayerId: number | null = null;
+  private lastTableType: TableType | null = null;
+  private lastCollisionTime: number = 0;
+  private lastRacketCollisionTime: number = 0;
+  private lastTableCollisionTime: number = 0;
 
   constructor() {
     const material = new CANNON.Material('ballMaterial');
@@ -17,6 +25,13 @@ export default class Ball {
     this.body.position.set(1, 1.5, 0); // x=0, y=0.8m, z=0 (탁구대 중앙 상공)
     this.body.velocity.set(0, 0, 0);
     this.body.angularVelocity.set(0, 0, 0);
+
+    // 충돌 데이터 초기화
+    this.lastRacketPlayerId = null;
+    this.lastTableType = null;
+    this.lastCollisionTime = 0;
+    this.lastRacketCollisionTime = 0;
+    this.lastTableCollisionTime = 0;
   }
 
   getMaterial() {
@@ -24,5 +39,51 @@ export default class Ball {
       throw new Error('Ball material is not defined');
     }
     return this.body.material;
+  }
+
+  // 충돌 데이터 기록 메서드
+  recordRacketCollision(playerId: number, currentTime: number) {
+    this.lastRacketPlayerId = playerId;
+    this.lastRacketCollisionTime = currentTime;
+    this.lastCollisionTime = currentTime;
+  }
+
+  recordTableCollision(tableType: TableType, currentTime: number) {
+    this.lastTableType = tableType;
+    this.lastTableCollisionTime = currentTime;
+    this.lastCollisionTime = currentTime;
+  }
+
+  // 충돌 데이터 조회 메서드
+  getLastRacketPlayerId(): number | null {
+    return this.lastRacketPlayerId;
+  }
+
+  getLastTableType(): TableType | null {
+    return this.lastTableType;
+  }
+
+  getLastCollisionTime(): number {
+    return this.lastCollisionTime;
+  }
+
+  getLastRacketCollisionTime(): number {
+    return this.lastRacketCollisionTime;
+  }
+
+  getLastTableCollisionTime(): number {
+    return this.lastTableCollisionTime;
+  }
+
+  hasCollidedWithRacketRecently(timeThreshold: number, currentTime: number): boolean {
+    return (
+      this.lastRacketCollisionTime > 0 && currentTime - this.lastRacketCollisionTime < timeThreshold
+    );
+  }
+
+  hasCollidedWithTableRecently(timeThreshold: number, currentTime: number): boolean {
+    return (
+      this.lastTableCollisionTime > 0 && currentTime - this.lastTableCollisionTime < timeThreshold
+    );
   }
 }

--- a/src/domain/physics/Ball.ts
+++ b/src/domain/physics/Ball.ts
@@ -74,16 +74,4 @@ export default class Ball {
   getLastTableCollisionTime(): number {
     return this.lastTableCollisionTime;
   }
-
-  hasCollidedWithRacketRecently(timeThreshold: number, currentTime: number): boolean {
-    return (
-      this.lastRacketCollisionTime > 0 && currentTime - this.lastRacketCollisionTime < timeThreshold
-    );
-  }
-
-  hasCollidedWithTableRecently(timeThreshold: number, currentTime: number): boolean {
-    return (
-      this.lastTableCollisionTime > 0 && currentTime - this.lastTableCollisionTime < timeThreshold
-    );
-  }
 }

--- a/src/domain/physics/GameSpace.ts
+++ b/src/domain/physics/GameSpace.ts
@@ -1,37 +1,51 @@
 import * as CANNON from 'cannon-es';
 import Ball from './Ball.js';
-import Table from './Table.js';
+import Table, { TableType } from './Table.js';
 import Racket from './Racket.js';
 
 export default class GameSpace {
   private readonly world: CANNON.World = new CANNON.World({
     gravity: new CANNON.Vec3(0, -9.81, 0),
   });
+  private gameTime: number = 0;
 
   constructor(
     private readonly ball: Ball,
-    private readonly table: Table,
+    private readonly tablePlayer1: Table,
+    private readonly tablePlayer2: Table,
     private readonly racket1: Racket,
     private readonly racket2: Racket,
   ) {
     this.world.broadphase = new CANNON.NaiveBroadphase();
     this.world.allowSleep = true;
 
-    this.world.addBody(table.body);
+    // 두 개의 테이블을 세계에 추가
+    this.world.addBody(tablePlayer1.body);
+    this.world.addBody(tablePlayer2.body);
     this.world.addBody(ball.body);
     this.world.addBody(racket1.body);
     this.world.addBody(racket2.body);
 
-    const tableMat = this.table.getMaterial();
+    const tablePlayer1Mat = this.tablePlayer1.getMaterial();
+    const tablePlayer2Mat = this.tablePlayer2.getMaterial();
     const ballMat = this.ball.getMaterial();
     const racket1Mat = this.racket1.getMaterial();
     const racket2Mat = this.racket2.getMaterial();
 
-    const contactMaterial = new CANNON.ContactMaterial(ballMat, tableMat, {
+    // 테이블 1과 공의 접촉 재질
+    const tablePlayer1ContactMaterial = new CANNON.ContactMaterial(ballMat, tablePlayer1Mat, {
       restitution: 0.9, // 0 = 탄성 없음, 1 = 완전 탄성 충돌
       friction: 0.1,
     });
-    const racketContactMaterial = new CANNON.ContactMaterial(ballMat, racket1Mat, {
+
+    // 테이블 2와 공의 접촉 재질
+    const tablePlayer2ContactMaterial = new CANNON.ContactMaterial(ballMat, tablePlayer2Mat, {
+      restitution: 0.9,
+      friction: 0.1,
+    });
+
+    // 라켓과 공의 접촉 재질
+    const racket1ContactMaterial = new CANNON.ContactMaterial(ballMat, racket1Mat, {
       restitution: 0.2,
       friction: 0.1,
     });
@@ -39,12 +53,55 @@ export default class GameSpace {
       restitution: 0.2,
       friction: 0.1,
     });
-    this.world.addContactMaterial(contactMaterial);
-    this.world.addContactMaterial(racketContactMaterial);
+
+    this.world.addContactMaterial(tablePlayer1ContactMaterial);
+    this.world.addContactMaterial(tablePlayer2ContactMaterial);
+    this.world.addContactMaterial(racket1ContactMaterial);
     this.world.addContactMaterial(racket2ContactMaterial);
+
+    // 충돌 이벤트 리스너 설정
+    this.setupCollisionListeners();
+  }
+
+  private setupCollisionListeners() {
+    // 충돌 시작 이벤트
+    this.world.addEventListener('beginContact', (event) => {
+      const { bodyA, bodyB } = event;
+
+      // Ball과 Racket 충돌 감지
+      if (
+        bodyA === this.ball.body &&
+        (bodyB === this.racket1.body || bodyB === this.racket2.body)
+      ) {
+        const racket = bodyB === this.racket1.body ? this.racket1 : this.racket2;
+        this.ball.recordRacketCollision(racket.getPlayerId(), this.gameTime);
+      } else if (
+        bodyB === this.ball.body &&
+        (bodyA === this.racket1.body || bodyA === this.racket2.body)
+      ) {
+        const racket = bodyA === this.racket1.body ? this.racket1 : this.racket2;
+        this.ball.recordRacketCollision(racket.getPlayerId(), this.gameTime);
+      }
+
+      // Ball과 Table 충돌 감지
+      if (
+        bodyA === this.ball.body &&
+        (bodyB === this.tablePlayer1.body || bodyB === this.tablePlayer2.body)
+      ) {
+        const table = bodyB === this.tablePlayer1.body ? this.tablePlayer1 : this.tablePlayer2;
+        this.ball.recordTableCollision(table.getTableType(), this.gameTime);
+      } else if (
+        bodyB === this.ball.body &&
+        (bodyA === this.tablePlayer1.body || bodyA === this.tablePlayer2.body)
+      ) {
+        const table = bodyA === this.tablePlayer1.body ? this.tablePlayer1 : this.tablePlayer2;
+        this.ball.recordTableCollision(table.getTableType(), this.gameTime);
+      }
+    });
   }
 
   step(dt: number) {
+    this.gameTime += dt;
     this.world.step(dt, dt, 10);
   }
 
@@ -85,5 +142,32 @@ export default class GameSpace {
     }
 
     throw new Error(`Player with ID ${playerId} does not have a racket.`);
+  }
+
+  // 충돌 데이터 조회 메서드
+  getBallLastRacketPlayerId(): number | null {
+    return this.ball.getLastRacketPlayerId();
+  }
+
+  getBallLastTableType(): TableType | null {
+    return this.ball.getLastTableType();
+  }
+
+  getBallCollisionData() {
+    return {
+      lastRacketPlayerId: this.ball.getLastRacketPlayerId(),
+      lastTableType: this.ball.getLastTableType(),
+      lastCollisionTime: this.ball.getLastCollisionTime(),
+      lastRacketCollisionTime: this.ball.getLastRacketCollisionTime(),
+      lastTableCollisionTime: this.ball.getLastTableCollisionTime(),
+    };
+  }
+
+  hasCollidedWithTableRecently(timeThreshold: number = 0.1): boolean {
+    return this.ball.hasCollidedWithTableRecently(timeThreshold, this.gameTime);
+  }
+
+  hasCollidedWithRacketRecently(timeThreshold: number = 0.1): boolean {
+    return this.ball.hasCollidedWithRacketRecently(timeThreshold, this.gameTime);
   }
 }

--- a/src/domain/physics/GameSpace.ts
+++ b/src/domain/physics/GameSpace.ts
@@ -65,39 +65,42 @@ export default class GameSpace {
 
   private setupCollisionListeners() {
     // 충돌 시작 이벤트
-    this.world.addEventListener('beginContact', (event) => {
-      const { bodyA, bodyB } = event;
+    this.world.addEventListener(
+      'beginContact',
+      (event: { bodyA: CANNON.Body; bodyB: CANNON.Body }) => {
+        const { bodyA, bodyB } = event;
 
-      // Ball과 Racket 충돌 감지
-      if (
-        bodyA === this.ball.body &&
-        (bodyB === this.racket1.body || bodyB === this.racket2.body)
-      ) {
-        const racket = bodyB === this.racket1.body ? this.racket1 : this.racket2;
-        this.ball.recordRacketCollision(racket.getPlayerId(), this.gameTime);
-      } else if (
-        bodyB === this.ball.body &&
-        (bodyA === this.racket1.body || bodyA === this.racket2.body)
-      ) {
-        const racket = bodyA === this.racket1.body ? this.racket1 : this.racket2;
-        this.ball.recordRacketCollision(racket.getPlayerId(), this.gameTime);
-      }
+        // Ball과 Racket 충돌 감지
+        if (
+          bodyA === this.ball.body &&
+          (bodyB === this.racket1.body || bodyB === this.racket2.body)
+        ) {
+          const racket = bodyB === this.racket1.body ? this.racket1 : this.racket2;
+          this.ball.recordRacketCollision(racket.getPlayerId(), this.gameTime);
+        } else if (
+          bodyB === this.ball.body &&
+          (bodyA === this.racket1.body || bodyA === this.racket2.body)
+        ) {
+          const racket = bodyA === this.racket1.body ? this.racket1 : this.racket2;
+          this.ball.recordRacketCollision(racket.getPlayerId(), this.gameTime);
+        }
 
-      // Ball과 Table 충돌 감지
-      if (
-        bodyA === this.ball.body &&
-        (bodyB === this.tablePlayer1.body || bodyB === this.tablePlayer2.body)
-      ) {
-        const table = bodyB === this.tablePlayer1.body ? this.tablePlayer1 : this.tablePlayer2;
-        this.ball.recordTableCollision(table.getTableType(), this.gameTime);
-      } else if (
-        bodyB === this.ball.body &&
-        (bodyA === this.tablePlayer1.body || bodyA === this.tablePlayer2.body)
-      ) {
-        const table = bodyA === this.tablePlayer1.body ? this.tablePlayer1 : this.tablePlayer2;
-        this.ball.recordTableCollision(table.getTableType(), this.gameTime);
-      }
-    });
+        // Ball과 Table 충돌 감지
+        if (
+          bodyA === this.ball.body &&
+          (bodyB === this.tablePlayer1.body || bodyB === this.tablePlayer2.body)
+        ) {
+          const table = bodyB === this.tablePlayer1.body ? this.tablePlayer1 : this.tablePlayer2;
+          this.ball.recordTableCollision(table.getTableType(), this.gameTime);
+        } else if (
+          bodyB === this.ball.body &&
+          (bodyA === this.tablePlayer1.body || bodyA === this.tablePlayer2.body)
+        ) {
+          const table = bodyA === this.tablePlayer1.body ? this.tablePlayer1 : this.tablePlayer2;
+          this.ball.recordTableCollision(table.getTableType(), this.gameTime);
+        }
+      },
+    );
   }
 
   step(dt: number) {

--- a/src/domain/physics/GameSpace.ts
+++ b/src/domain/physics/GameSpace.ts
@@ -2,6 +2,7 @@ import * as CANNON from 'cannon-es';
 import Ball from './Ball.js';
 import Table, { TableType } from './Table.js';
 import Racket from './Racket.js';
+import { Body } from 'objects/Body';
 
 export default class GameSpace {
   private readonly world: CANNON.World = new CANNON.World({
@@ -59,47 +60,50 @@ export default class GameSpace {
     this.world.addContactMaterial(racket2ContactMaterial);
 
     // 충돌 이벤트 리스너 설정
-    this.setupCollisionListeners();
-  }
-
-  private setupCollisionListeners() {
-    // 충돌 시작 이벤트
     this.world.addEventListener(
       'beginContact',
-      (event: { bodyA: CANNON.Body; bodyB: CANNON.Body }) => {
-        const { bodyA, bodyB } = event;
-
-        // Ball과 Racket 충돌 감지
-        if (
-          bodyA === this.ball.body &&
-          (bodyB === this.racket1.body || bodyB === this.racket2.body)
-        ) {
-          const racket = bodyB === this.racket1.body ? this.racket1 : this.racket2;
-          this.ball.recordRacketCollision(racket.getPlayerId(), this.gameTime);
-        } else if (
-          bodyB === this.ball.body &&
-          (bodyA === this.racket1.body || bodyA === this.racket2.body)
-        ) {
-          const racket = bodyA === this.racket1.body ? this.racket1 : this.racket2;
-          this.ball.recordRacketCollision(racket.getPlayerId(), this.gameTime);
-        }
-
-        // Ball과 Table 충돌 감지
-        if (
-          bodyA === this.ball.body &&
-          (bodyB === this.tablePlayer1.body || bodyB === this.tablePlayer2.body)
-        ) {
-          const table = bodyB === this.tablePlayer1.body ? this.tablePlayer1 : this.tablePlayer2;
-          this.ball.recordTableCollision(table.getTableType(), this.gameTime);
-        } else if (
-          bodyB === this.ball.body &&
-          (bodyA === this.tablePlayer1.body || bodyA === this.tablePlayer2.body)
-        ) {
-          const table = bodyA === this.tablePlayer1.body ? this.tablePlayer1 : this.tablePlayer2;
-          this.ball.recordTableCollision(table.getTableType(), this.gameTime);
-        }
-      },
+      (event: { bodyA: CANNON.Body; bodyB: CANNON.Body }) => this.collisionListeners(event),
     );
+  }
+
+  private collisionListeners(event: { bodyA: CANNON.Body; bodyB: CANNON.Body }) {
+    const { bodyA, bodyB } = event;
+    const ballBody = this.ball.body;
+
+    const racketMap = new Map<CANNON.Body, Racket>([
+      [this.racket1.body, this.racket1],
+      [this.racket2.body, this.racket2],
+    ]);
+    const tableMap = new Map<CANNON.Body, Table>([
+      [this.tablePlayer1.body, this.tablePlayer1],
+      [this.tablePlayer2.body, this.tablePlayer2],
+    ]);
+
+    const otherBody = this.getOtherBody(ballBody, bodyA, bodyB);
+    if (!otherBody) {
+      return;
+    }
+
+    const racket = racketMap.get(otherBody);
+    if (racket) {
+      this.ball.recordRacketCollision(racket.getPlayerId(), this.gameTime);
+      return;
+    }
+
+    const table = tableMap.get(otherBody);
+    if (table) {
+      this.ball.recordTableCollision(table.getTableType(), this.gameTime);
+      return;
+    }
+  }
+
+  private getOtherBody(ballBody: Body, bodyA: Body, bodyB: Body) {
+    if (bodyA === ballBody) {
+      return bodyB;
+    } else if (bodyB === ballBody) {
+      return bodyA;
+    }
+    return null; // 볼과 관련 없는 충돌
   }
 
   step(dt: number) {

--- a/src/domain/physics/GameSpace.ts
+++ b/src/domain/physics/GameSpace.ts
@@ -19,7 +19,6 @@ export default class GameSpace {
     this.world.broadphase = new CANNON.NaiveBroadphase();
     this.world.allowSleep = true;
 
-    // 두 개의 테이블을 세계에 추가
     this.world.addBody(tablePlayer1.body);
     this.world.addBody(tablePlayer2.body);
     this.world.addBody(ball.body);
@@ -164,13 +163,5 @@ export default class GameSpace {
       lastRacketCollisionTime: this.ball.getLastRacketCollisionTime(),
       lastTableCollisionTime: this.ball.getLastTableCollisionTime(),
     };
-  }
-
-  hasCollidedWithTableRecently(timeThreshold: number = 0.1): boolean {
-    return this.ball.hasCollidedWithTableRecently(timeThreshold, this.gameTime);
-  }
-
-  hasCollidedWithRacketRecently(timeThreshold: number = 0.1): boolean {
-    return this.ball.hasCollidedWithRacketRecently(timeThreshold, this.gameTime);
   }
 }

--- a/src/domain/physics/GameSpace.ts
+++ b/src/domain/physics/GameSpace.ts
@@ -2,7 +2,6 @@ import * as CANNON from 'cannon-es';
 import Ball from './Ball.js';
 import Table, { TableType } from './Table.js';
 import Racket from './Racket.js';
-import { Body } from 'objects/Body';
 
 export default class GameSpace {
   private readonly world: CANNON.World = new CANNON.World({
@@ -97,7 +96,7 @@ export default class GameSpace {
     }
   }
 
-  private getOtherBody(ballBody: Body, bodyA: Body, bodyB: Body) {
+  private getOtherBody(ballBody: CANNON.Body, bodyA: CANNON.Body, bodyB: CANNON.Body) {
     if (bodyA === ballBody) {
       return bodyB;
     } else if (bodyB === ballBody) {

--- a/src/domain/physics/Table.ts
+++ b/src/domain/physics/Table.ts
@@ -13,7 +13,7 @@ export default class Table {
     tableType: TableType,
     halfWidth = 1.5 / 2, // 0.7625m
     halfThickness = 0.5, // 상판 두께
-    halfLength = 3 / 4, // 테이블 길이 반으로 분할 (원래 3/2 였던 것을 절반인 3/4로)
+    halfLength = 1.5 / 4, // 테이블 길이 반으로 분할
   ) {
     this.tableType = tableType;
     const material = new CANNON.Material(`table${tableType}Material`);

--- a/src/domain/physics/Table.ts
+++ b/src/domain/physics/Table.ts
@@ -13,7 +13,7 @@ export default class Table {
     tableType: TableType,
     halfWidth = 1.5 / 2, // 0.7625m
     halfThickness = 0.5, // 상판 두께
-    halfLength = 1.5 / 4, // 테이블 길이 반으로 분할
+    halfLength = 1.5 / 2, // 테이블 길이 반으로 분할
   ) {
     this.tableType = tableType;
     const material = new CANNON.Material(`table${tableType}Material`);

--- a/src/domain/physics/Table.ts
+++ b/src/domain/physics/Table.ts
@@ -1,20 +1,31 @@
 import * as CANNON from 'cannon-es';
 
+export enum TableType {
+  PLAYER1 = 'PLAYER1',
+  PLAYER2 = 'PLAYER2',
+}
+
 export default class Table {
   public body: CANNON.Body;
+  public tableType: TableType;
 
   constructor(
+    tableType: TableType,
     halfWidth = 1.5 / 2, // 0.7625m
     halfThickness = 0.5, // 상판 두께
-    halfLength = 3 / 2, // 1.37m
+    halfLength = 3 / 4, // 테이블 길이 반으로 분할 (원래 3/2 였던 것을 절반인 3/4로)
   ) {
-    const material = new CANNON.Material('tableMaterial');
+    this.tableType = tableType;
+    const material = new CANNON.Material(`table${tableType}Material`);
     this.body = new CANNON.Body({
       type: CANNON.Body.STATIC,
       shape: new CANNON.Box(new CANNON.Vec3(halfLength, halfThickness, halfWidth)),
       material,
     });
-    this.body.position.set(0, 0.76 - halfThickness, 0); // 상판 중심이 높이 0.76m에 오도록
+
+    // 테이블 위치 설정: player1 테이블은 양수 x 영역, player2 테이블은 음수 x 영역
+    const xPosition = tableType === TableType.PLAYER1 ? halfLength : -halfLength;
+    this.body.position.set(xPosition, 0.76 - halfThickness, 0); // 상판 중심이 높이 0.76m에 오도록
   }
 
   getMaterial(): CANNON.Material {
@@ -22,5 +33,9 @@ export default class Table {
       throw new Error('Table body material is not defined');
     }
     return this.body.material;
+  }
+
+  getTableType(): TableType {
+    return this.tableType;
   }
 }

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -2,7 +2,7 @@ import { pino } from 'pino';
 
 export const logger = pino(
   {
-    level: 'debug',
+    level: process.env.LOG_LEVEL || 'info',
   },
   pino.transport({
     target: 'pino-pretty',

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -1,13 +1,15 @@
 import { pino } from 'pino';
 
-export const logger = pino({
-  transport: {
-    target: 'pino-pretty',
+export const logger = pino(
+  {
     level: 'debug',
+  },
+  pino.transport({
+    target: 'pino-pretty',
     options: {
       colorize: true,
       translateTime: 'yyyy-mm-dd HH:MM:ss',
       ignore: 'pid,hostname',
     },
-  },
-});
+  }),
+);

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -3,7 +3,7 @@ import { pino } from 'pino';
 export const logger = pino({
   transport: {
     target: 'pino-pretty',
-    level: process.env.LOG_LEVEL || 'info',
+    level: 'debug',
     options: {
       colorize: true,
       translateTime: 'yyyy-mm-dd HH:MM:ss',

--- a/src/network/match.middleware.ts
+++ b/src/network/match.middleware.ts
@@ -1,4 +1,5 @@
 import { Socket } from 'socket.io';
+import GameSession from '../domain/GameSession.js';
 
 type NextFunction = (err?: Error) => void;
 
@@ -20,7 +21,11 @@ export async function matchMiddleware(socket: Socket, next: NextFunction) {
       return next(new Error('Invalid match ID'));
     }
 
-    // TODO: Add logic to check if the user is a participant in the match
+    const gameSession: GameSession =
+      socket.nsp.server.diContainer.resolve<GameSession>('gameSession');
+    if (!gameSession.getPlayerIds(parsedMatchId).includes(userId)) {
+      return next(new Error(`User ${userId} is not part of match ${parsedMatchId}`));
+    }
 
     socket.data.matchId = parsedMatchId;
     next();

--- a/src/network/socket.ts
+++ b/src/network/socket.ts
@@ -34,7 +34,7 @@ export const registerSocket = (diContainer: AwilixContainer, io: Server) => {
       const { x, y, z } = data;
       if (!gameSession.isExist(matchId)) {
         logger.error(`Match ${matchId} does not exist for player ${playerId}`);
-        return;
+        throw new Error(`Match ${matchId} does not exist`);
       }
       gameSession.updateRacketPosition(matchId, playerId, x, y, z);
     });

--- a/src/network/socket.ts
+++ b/src/network/socket.ts
@@ -5,6 +5,7 @@ import { matchMiddleware } from './match.middleware.js';
 import GameSession from '../domain/GameSession.js';
 import { MATCH_SOCKET_EVENTS } from './match.event.js';
 import { socketPlayerIdSchema } from './schemas/player-id.socket.schema.js';
+import { socketErrorHandler } from './utils/errorHandler.js';
 
 export const registerSocket = (diContainer: AwilixContainer, io: Server) => {
   io.use(socketMiddleware);
@@ -30,14 +31,18 @@ export const registerSocket = (diContainer: AwilixContainer, io: Server) => {
     socket
       .to(`match:${matchId}`)
       .emit(MATCH_SOCKET_EVENTS.PLAYER_CONNECTED, socketPlayerIdSchema.parse({ playerId }));
-    socket.on(MATCH_SOCKET_EVENTS.RACKET, (data) => {
-      const { x, y, z } = data;
-      if (!gameSession.isExist(matchId)) {
-        logger.error(`Match ${matchId} does not exist for player ${playerId}`);
-        throw new Error(`Match ${matchId} does not exist`);
-      }
-      gameSession.updateRacketPosition(matchId, playerId, x, y, z);
-    });
+
+    socket.on(
+      MATCH_SOCKET_EVENTS.RACKET,
+      socketErrorHandler(socket, logger, (data: { x: number; y: number; z: number }) => {
+        const { x, y, z } = data;
+        if (!gameSession.isExist(matchId)) {
+          logger.error(`Match ${matchId} does not exist for player ${playerId}`);
+          throw new Error(`Match ${matchId} does not exist`);
+        }
+        gameSession.updateRacketPosition(matchId, playerId, x, y, z);
+      }),
+    );
 
     socket.on('disconnect', () => {
       logger.info(`User ${playerId} disconnected from match ${matchId}`);


### PR DESCRIPTION
## 📝 작업 내용

- 판정 및 점수 계산을 위해 충돌 관련 데이터를 저장할 수 있도록 합니다.
- 공이 마지막으로 어떤 플레이어의 채에 충돌하였는지, 어떤 쪽의 테이블에 충동하였는지, 등을 저장합니다.
- 현재 테이블 오브젝트는 하나로 되어있는데 2개로 나누어서 처리해야 합니다. 때문에 1개가 아닌 2개로 나누어서 테이블을 구성하도록 변경합니다.


<img width="477" alt="image" src="https://github.com/user-attachments/assets/c51c00e5-e833-49da-af46-e4eab5983193" />

- BallCollisionData:를 찍은 시점에
  - 라켓 충돌 없음 (lastRacketPlayerId: null)
  - PLAYER1 쪽 테이블과 마지막 충돌 (lastTableType: "PLAYER1")
  - 충돌 시점은 약 6.20초 (lastCollisionTime, lastTableCollisionTime)

<img width="475" alt="image" src="https://github.com/user-attachments/assets/d8b2a9c4-94e7-45fd-8a03-41bc38a65baa" />

- 약 17.20초 지점에 다시 BallCollisionData:
  - 라켓 충돌이 먼저 발생 (lastRacketCollisionTime: 16.6833초)
  - 이어 PLAYER2 쪽 테이블과 충돌 (lastTableType: "PLAYER2", lastTableCollisionTime: 17.20초)
  - 충돌한 라켓의 플레이어 ID는 222 (lastRacketPlayerId: 222)